### PR TITLE
Compile Static Binary

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target = "x86_64-unknown-linux-musl"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,17 @@ rust:
 
 cache: cargo
 
+addons:
+  apt:
+    packages:
+      - musl-tools
+
 matrix:
   allow_failures:
     - rust: nightly
   fast_finish: true
 
+before_install: rustup target install x86_64-unknown-linux-musl
 install: make release
 script: cargo test --verbose
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "escalator"
-version = "0.1.0"
+version = "1.0.1"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log4rs 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "escalator"
-version = "0.1.0"
+version = "1.0.1"
 authors = ["Naftuli Kay <me@naftuli.wtf>"]
 edition = "2018"
 

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,25 @@
 #!/usr/bin/make -f
 
+GLIBC_TARGET:=x86_64-unknown-linux-gnu
+MUSL_TARGET:=x86_64-unknown-linux-musl
+
 .PHONY: all
 
 build-release:
-	@cargo build --release
+	@cargo build --release --target=$(GLIBC_TARGET)
+	@cargo build --release --target=$(MUSL_TARGET)
 
 completions: build-release
 	@mkdir -p target/completions.d/
-	@target/release/escalator-completion bash > target/completions.d/bash
-	@target/release/escalator-completion fish > target/completions.d/fish
-	@target/release/escalator-completion zsh > target/completions.d/zsh
-	@target/release/escalator-completion elvish > target/completions.d/elvish
+	@target/$(MUSL_TARGET)/release/escalator-completion bash > target/completions.d/bash
+	@target/$(MUSL_TARGET)/release/escalator-completion fish > target/completions.d/fish
+	@target/$(MUSL_TARGET)/release/escalator-completion zsh > target/completions.d/zsh
+	@target/$(MUSL_TARGET)/release/escalator-completion elvish > target/completions.d/elvish
+
+deploy: build-release completions
+	@mkdir -p target/deploy
+	@rsync -a --delete target/completions.d/ target/deploy/completions.d/
+	@cp target/$(GLIBC_TARGET)/release/escalator target/deploy/escalator-$(GLIBC_TARGET)
+	@cp target/$(MUSL_TARGET)/release/escalator target/deploy/escalator-$(MUSL_TARGET)
 
 release: build-release completions


### PR DESCRIPTION
Before, it was a linked GLibc binary, which introduced per-distro conflicts.

Now it's a static musl libc binary.